### PR TITLE
Fix phantom complex-index churn on every migrations add

### DIFF
--- a/EFCore.ComplexIndexes.Tests/PhantomIndexChurnTests.cs
+++ b/EFCore.ComplexIndexes.Tests/PhantomIndexChurnTests.cs
@@ -1,0 +1,184 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations.Operations;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Update.Internal;
+
+namespace EFCore.ComplexIndexes.Tests;
+
+/// <summary>
+/// Regression tests for the phantom complex-index churn: every <c>migrations add</c> re-creating
+/// identical indexes. Two independent causes:
+/// (1) the diff collects ALL non-core property annotations, so the snapshot model's serialized
+///     <c>Relational:ColumnType</c> (absent on the code model) makes every complex index differ;
+/// (2) array-valued provider annotations (e.g. operator classes) are compared/hashed by reference,
+///     so structurally-equal indexes never match.
+/// </summary>
+[TestClass]
+public class PhantomIndexChurnTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+
+    public PhantomIndexChurnTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+    }
+
+    public void Dispose() => _connection.Dispose();
+
+    private IRelationalModel BuildRelationalModel<TContext>()
+        where TContext : DbContext
+    {
+        var options = new DbContextOptionsBuilder<TContext>().UseSqlite(_connection).Options;
+        using var context = (TContext)Activator.CreateInstance(typeof(TContext), options)!;
+        return context.GetService<IDesignTimeModel>().Model.GetRelationalModel();
+    }
+
+    private IReadOnlyList<MigrationOperation> GetDifferences(IRelationalModel? source, IRelationalModel? target)
+    {
+        var options = new DbContextOptionsBuilder().UseSqlite(_connection).Options;
+        using var context = new EmptyContext(options);
+        var differ = new CustomMigrationsModelDiffer(
+            context.GetService<IRelationalTypeMappingSource>(),
+            context.GetService<IMigrationsAnnotationProvider>(),
+            context.GetService<IRelationalAnnotationProvider>(),
+            context.GetService<IRowIdentityMapFactory>(),
+            context.GetService<CommandBatchPreparerDependencies>());
+        return differ.GetDifferences(source, target);
+    }
+
+    private class EmptyContext(DbContextOptions options) : DbContext(options);
+
+    private class Address
+    {
+        public string Value { get; set; } = "";
+    }
+
+    private class Person
+    {
+        public Guid Id { get; set; }
+        public Address Address { get; set; } = new();
+    }
+
+    // Index with an array-valued provider annotation (e.g. operator classes).
+    private class ArrayAnnotationContext(DbContextOptions<ArrayAnnotationContext> options) : DbContext(options)
+    {
+        public DbSet<Person> People => Set<Person>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+            modelBuilder.Entity<Person>(b =>
+            {
+                b.ToTable("person");
+                b.HasKey(x => x.Id);
+                b.ComplexProperty(x => x.Address, c =>
+                    c.Property(x => x.Value).HasColumnName("value")
+                     .HasComplexIndex(ix => ix.HasAnnotation("Test:Operators", new[] { "op_a", "op_b" })));
+            });
+    }
+
+    // Identical index/value as ArrayAnnotationContext, but a distinct context type — so EF's
+    // per-context model cache yields a separate model (and a separate array instance), exactly as
+    // the snapshot model and code model differ at `migrations add` time.
+    private class ArrayAnnotationCloneContext(DbContextOptions<ArrayAnnotationCloneContext> options) : DbContext(options)
+    {
+        public DbSet<Person> People => Set<Person>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+            modelBuilder.Entity<Person>(b =>
+            {
+                b.ToTable("person");
+                b.HasKey(x => x.Id);
+                b.ComplexProperty(x => x.Address, c =>
+                    c.Property(x => x.Value).HasColumnName("value")
+                     .HasComplexIndex(ix => ix.HasAnnotation("Test:Operators", new[] { "op_a", "op_b" })));
+            });
+    }
+
+    // Same index, different array value — a genuine change that MUST still be detected.
+    private class ArrayAnnotationChangedContext(DbContextOptions<ArrayAnnotationChangedContext> options) : DbContext(options)
+    {
+        public DbSet<Person> People => Set<Person>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+            modelBuilder.Entity<Person>(b =>
+            {
+                b.ToTable("person");
+                b.HasKey(x => x.Id);
+                b.ComplexProperty(x => x.Address, c =>
+                    c.Property(x => x.Value).HasColumnName("value")
+                     .HasComplexIndex(ix => ix.HasAnnotation("Test:Operators", new[] { "op_a", "op_c" })));
+            });
+    }
+
+    // Mimics the SNAPSHOT model: column type serialized via HasColumnType.
+    private class ExplicitColumnTypeContext(DbContextOptions<ExplicitColumnTypeContext> options) : DbContext(options)
+    {
+        public DbSet<Person> People => Set<Person>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+            modelBuilder.Entity<Person>(b =>
+            {
+                b.ToTable("person");
+                b.HasKey(x => x.Id);
+                b.ComplexProperty(x => x.Address, c =>
+                    c.Property(x => x.Value).HasColumnName("value").HasColumnType("TEXT")
+                     .HasComplexIndex(isUnique: true));
+            });
+    }
+
+    // Mimics the CODE model: column type left to convention (no explicit annotation).
+    private class ConventionColumnTypeContext(DbContextOptions<ConventionColumnTypeContext> options) : DbContext(options)
+    {
+        public DbSet<Person> People => Set<Person>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+            modelBuilder.Entity<Person>(b =>
+            {
+                b.ToTable("person");
+                b.HasKey(x => x.Id);
+                b.ComplexProperty(x => x.Address, c =>
+                    c.Property(x => x.Value).HasColumnName("value")
+                     .HasComplexIndex(isUnique: true));
+            });
+    }
+
+    [TestMethod(DisplayName = "Array-valued annotation: identical models produce no index operations")]
+    public void Array_annotation_no_change_produces_no_operations()
+    {
+        var source = BuildRelationalModel<ArrayAnnotationContext>();
+        var target = BuildRelationalModel<ArrayAnnotationCloneContext>();
+
+        var operations = GetDifferences(source, target);
+
+        Assert.IsEmpty(operations.OfType<CreateIndexOperation>());
+        Assert.IsEmpty(operations.OfType<DropIndexOperation>());
+    }
+
+    [TestMethod(DisplayName = "ColumnType asymmetry (snapshot vs code model) produces no index operations")]
+    public void ColumnType_asymmetry_produces_no_operations()
+    {
+        var source = BuildRelationalModel<ExplicitColumnTypeContext>();
+        var target = BuildRelationalModel<ConventionColumnTypeContext>();
+
+        var operations = GetDifferences(source, target);
+
+        Assert.IsEmpty(operations.OfType<CreateIndexOperation>());
+        Assert.IsEmpty(operations.OfType<DropIndexOperation>());
+    }
+
+    [TestMethod(DisplayName = "Array-valued annotation: a changed value is still detected")]
+    public void Array_annotation_value_change_is_detected()
+    {
+        var source = BuildRelationalModel<ArrayAnnotationContext>();
+        var target = BuildRelationalModel<ArrayAnnotationChangedContext>();
+
+        var operations = GetDifferences(source, target);
+
+        Assert.IsNotEmpty(operations.OfType<CreateIndexOperation>());
+        Assert.IsNotEmpty(operations.OfType<DropIndexOperation>());
+    }
+}

--- a/EFCore.ComplexIndexes/CustomMigrationsModelDiffer.cs
+++ b/EFCore.ComplexIndexes/CustomMigrationsModelDiffer.cs
@@ -107,6 +107,15 @@ public class CustomMigrationsModelDiffer(
         ComplexIndexAnnotations.CompositeIndexes
     ];
 
+    // EF relational column-facet annotations that are meaningless on an index operation. The
+    // snapshot model serializes the column type (HasColumnType) so it carries Relational:ColumnType,
+    // while the code model leaves it implicit (no annotation). Collecting it would make the source
+    // and target descriptors differ for every complex index, producing phantom drop/create churn.
+    private static readonly HashSet<string> NonIndexColumnAnnotationKeys =
+    [
+        "Relational:ColumnType"
+    ];
+
     private static void ScanForSingleColumnIndexes(
         ITypeBase                typeBase,
         string                   tableName,
@@ -141,11 +150,11 @@ public class CustomMigrationsModelDiffer(
             var indexName = property.FindAnnotation(ComplexIndexAnnotations.IndexName)?.Value as string
                          ?? $"IX_{tableName}_{columnName}";
 
-            // Collect all non-core annotations as provider annotations
+            // Collect provider annotations, skipping core keys and non-index column facets
             var providerAnnotations = new Dictionary<string, object?>();
             foreach (var ann in property.GetAnnotations())
             {
-                if (!CoreAnnotationKeys.Contains(ann.Name))
+                if (!CoreAnnotationKeys.Contains(ann.Name) && !NonIndexColumnAnnotationKeys.Contains(ann.Name))
                     providerAnnotations[ann.Name] = ann.Value;
             }
 
@@ -294,10 +303,21 @@ public class CustomMigrationsModelDiffer(
             foreach (var (key, value) in ProviderAnnotations)
             {
                 if (!other.ProviderAnnotations.TryGetValue(key, out var otherValue)) return false;
-                if (!Equals(value, otherValue)) return false;
+                if (!AnnotationValueEquals(value, otherValue)) return false;
             }
 
             return true;
+        }
+
+        // Annotation values may be arrays (e.g. operator classes / included columns). object.Equals
+        // compares arrays by reference, so structurally-equal values from two model builds never
+        // match — compare such values by sequence instead.
+        private static bool AnnotationValueEquals(object? a, object? b)
+        {
+            if (a is string || b is string) return Equals(a, b);
+            if (a is System.Collections.IEnumerable ea && b is System.Collections.IEnumerable eb)
+                return ea.Cast<object?>().SequenceEqual(eb.Cast<object?>());
+            return Equals(a, b);
         }
 
         public override int GetHashCode()
@@ -316,7 +336,12 @@ public class CustomMigrationsModelDiffer(
             foreach (var (key, value) in ProviderAnnotations.OrderBy(kv => kv.Key))
             {
                 hash.Add(key);
-                hash.Add(value);
+
+                // Hash array contents (not the reference) to stay consistent with AnnotationValueEquals.
+                if (value is not string && value is System.Collections.IEnumerable seq)
+                    foreach (var item in seq) hash.Add(item);
+                else
+                    hash.Add(value);
             }
 
             return hash.ToHashCode();


### PR DESCRIPTION
Every `dotnet ef migrations add` re-created identical complex-type-property indexes (DropIndex + CreateIndex) while the model snapshot stayed unchanged. Two independent causes in CustomMigrationsModelDiffer.IndexDescriptor:

1. It compared ALL non-core property annotations. The snapshot model serializes the column type (HasColumnType) and so carries Relational:ColumnType, which the code model leaves implicit — making the source/target descriptors differ for every complex index. Exclude non-index column facets (Relational:ColumnType) when collecting provider annotations.

2. Array-valued provider annotations (e.g. Npgsql:IndexOperators / IndexInclude) were compared with object.Equals and hashed by reference, so structurally-equal values from two model builds never matched. Compare them by sequence and hash their contents (kept consistent across Equals and GetHashCode).

Adds PhantomIndexChurnTests reproducing both causes in isolation and guarding that a genuine index change is still detected.