### PR TITLE
Consumer smoke test, and NU1903 rationale

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -110,6 +110,26 @@ jobs:
           path: TestResults/*.trx
           if-no-files-found: ignore
 
+  # The only job that exercises the delivery chain rather than the code: NuGet restore, the packaged
+  # .targets injecting the design-time attribute, EF's host discovering it, and a real
+  # `dotnet ef migrations add`. Deliberately independent of the other jobs so it reports in parallel.
+  #
+  # No database is involved — scaffolding a migration never connects.
+  consumer:
+    name: Consumer smoke test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Scaffold a migration from a throwaway consumer project
+        run: ./test/consumer-smoke-test.sh
+
   pack:
     name: Pack
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,12 @@ jobs:
       - name: Pack
         run: dotnet pack -c Release --no-build -o dist
 
+      # Installs the packages just packed into a throwaway project outside this repository and runs a
+      # real `dotnet ef migrations add`. Passing dist means the artifacts published are the artifacts
+      # tested, rather than a fresh pack that happens to be built from the same commit.
+      - name: Consumer smoke test
+        run: ./test/consumer-smoke-test.sh dist
+
       # One CycloneDX SBOM per package, describing what a consumer actually takes on.
       #
       # --exclude-filter drops Microsoft.EntityFrameworkCore.Design and its whole subtree. That

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,22 @@ below exist because ordinary review does not catch it.
 | `PackagingConventionTests` | Every package ships its own README as `PackageReadmeFile`; `.targets` ship to both `build/` and `buildTransitive/`, reference a real `IDesignTimeServices` in their own assembly, and set `ForProvider` on satellites but not on core. |
 | `BuilderApiParityTests` | Every key in a satellite's annotation whitelist is reachable from a builder method. `SqlServer:DataCompression` sat whitelisted with no API for a full release; this catches that class of drift by invoking every builder extension and diffing the keys it sets. |
 
+**`test/consumer-smoke-test.sh`** is the only check that exercises *delivery* rather than code. Every
+other layer is verified in isolation and in-process; this one packs the nupkgs, restores them into a
+throwaway project created **outside the repository** (inside it, `Directory.Build.props` would apply
+and the project would stop resembling a consumer's), and runs a real `dotnet ef migrations add`. It
+then asserts on scaffolded content — never on the exit code, because the failure being hunted is a
+`migrations add` that succeeds while silently omitting every index. Neutering both `.targets` files
+reproduces exactly that: table and columns scaffold fine, indexes vanish, exit code 0.
+
+Two things in it are load-bearing and easy to "simplify" away. `NUGET_PACKAGES` is redirected to a
+private folder because NuGet resolves id+version from the global packages folder before consulting
+any source — with the version pinned at 5.0.2 a locally built package is shadowed by whatever 5.0.2
+was restored before, up to and including the one on nuget.org, and the test silently reports on the
+wrong artifact. And `<clear/>` in the generated `nuget.config` stops nuget.org from satisfying the
+restore on its own. Note also that the two `.targets` are *redundant* by design: sabotaging either
+one alone still yields correct migrations, because the surviving registration covers it.
+
 **`MigrationHarness`** (under `test/…/Harness/`) is the shared rig: build a model from a
 `DbContext`, construct any differ, render operations through either the stock provider generator or
 this package's. Investigating a suspected differ bug should be three lines, not a re-derived

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,6 +22,14 @@
         passes depends on advisories published upstream rather than on anything in this commit; as an
         error it would break unrelated CI runs at unpredictable moments. It must stay visible, so it
         is exempted rather than suppressed with NoWarn.
+
+        As of 5.0.2 it fires for System.Security.Cryptography.Xml 9.0.0, reached only through
+        Microsoft.EntityFrameworkCore.Design -> Microsoft.Build.Tasks.Core. That reference is
+        PrivateAssets=all, so the package never declares it and consumers never restore it: the
+        exposure is limited to machines building this repository. Bumping Design to 10.0.11 clears
+        the warning but drags the direct Abstractions reference up with it (NU1605 rejects the
+        downgrade), which would raise the consumer's EF Core floor from 10.0.0 to 10.0.11. Keeping
+        the floor low is worth more than silencing a warning that describes no consumer risk.
     -->
     <PropertyGroup>
         <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>

--- a/test/consumer-smoke-test.sh
+++ b/test/consumer-smoke-test.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+#
+# End-to-end check of the path a real consumer takes, which nothing else in the suite covers.
+#
+# The unit tests construct the differ in-process; the integration tests apply operations the differ
+# already produced. Neither exercises the chain that actually delivers this package: NuGet restore ->
+# the packaged .targets injecting DesignTimeServicesReferenceAttribute -> EF's design-time host
+# discovering it -> the right differ winning -> `dotnet ef migrations add` scaffolding real SQL.
+#
+# That chain is where a lost .targets, a wrong ForProvider, or a broken registration degrades
+# silently: `migrations add` still succeeds, it just quietly omits the indexes. So the assertions
+# here are about scaffolded *content*, never about the exit code alone.
+#
+# The consumer project is created outside the repository on purpose. Inside it, Directory.Build.props
+# would apply and the project would stop resembling anything a consumer builds.
+#
+# Usage: consumer-smoke-test.sh [feed-directory]
+#   With no argument the packages are packed fresh. Pass a directory of existing .nupkg files
+#   (the release workflow passes its pack output) to test exactly the artifacts being shipped.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+app="$work/app"
+feed="${1:-}"
+
+# A private package cache, and not an optimisation to skip.
+#
+# NuGet resolves id+version from the global packages folder before it ever looks at a source, so with
+# the version number held at 5.0.2 a locally built package is shadowed by whatever 5.0.2 was restored
+# before — including the one published on nuget.org. The test then reports on a package that has
+# nothing to do with the working tree. It passed a deliberately sabotaged build that way.
+export NUGET_PACKAGES="$work/packages"
+
+version="$(dotnet msbuild "$repo_root/src/EFCore.ComplexIndexes/EFCore.ComplexIndexes.csproj" -getProperty:Version)"
+version="$(echo "$version" | tr -d '[:space:]')"
+
+if [[ -z "$feed" ]]; then
+    feed="$work/feed"
+    echo "==> Packing $version"
+    dotnet pack "$repo_root/EFCore.ComplexIndexes.slnx" -c Release -o "$feed" --verbosity quiet
+else
+    feed="$(cd "$feed" && pwd)"
+    echo "==> Using existing feed: $feed"
+fi
+
+ls "$feed"/EFCore.ComplexIndexes."$version".nupkg >/dev/null
+
+echo "==> Creating a consumer project at $app"
+mkdir -p "$app"
+cd "$app"
+dotnet new console --framework net10.0 --output . --verbosity quiet >/dev/null
+
+# <clear/> matters: without it a same-named package on nuget.org could satisfy the restore and the
+# test would pass without ever touching the freshly built artifacts.
+cat > nuget.config <<XML
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="local" value="$feed" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>
+XML
+
+cat > Program.cs <<'CSHARP'
+using EFCore.ComplexIndexes;
+using Microsoft.EntityFrameworkCore;
+
+Console.WriteLine("consumer");
+
+public sealed class Address
+{
+    public string City { get; set; } = "";
+    public string Zip  { get; set; } = "";
+}
+
+public sealed class Order
+{
+    public int     Id   { get; set; }
+    public Address Ship { get; set; } = new();
+}
+
+public sealed class ShopContext : DbContext
+{
+    public DbSet<Order> Orders => Set<Order>();
+
+    protected override void OnConfiguring(DbContextOptionsBuilder options)
+        => options.UseNpgsql("Host=localhost;Database=smoke");
+
+    protected override void OnModelCreating(ModelBuilder model)
+    {
+        model.Entity<Order>(entity =>
+        {
+            entity.ComplexProperty(o => o.Ship, ship => ship.Property(a => a.City).HasComplexIndex());
+            entity.HasComplexCompositeIndex(o => new { o.Ship.City, o.Ship.Zip });
+        });
+    }
+}
+CSHARP
+
+echo "==> Restoring the packed satellite from the local feed"
+dotnet add package EFCore.ComplexIndexes.PostgreSQL --version "$version" --source "$feed" >/dev/null
+dotnet add package Microsoft.EntityFrameworkCore.Design >/dev/null
+
+dotnet new tool-manifest >/dev/null
+dotnet tool install dotnet-ef --version "10.*" >/dev/null
+
+echo "==> dotnet ef migrations add Initial"
+dotnet tool run dotnet-ef migrations add Initial >/dev/null
+
+migration="$(find Migrations -name '*_Initial.cs' | head -1)"
+[[ -n "$migration" ]] || { echo "FAIL: no migration was scaffolded"; exit 1; }
+
+failed=0
+assert_contains() {
+    if grep -q "$1" "$2"; then
+        echo "  ok: $3"
+    else
+        echo "  FAIL: $3 (expected '$1' in $(basename "$2"))"
+        failed=1
+    fi
+}
+
+echo "==> Asserting the scaffolded migration"
+assert_contains 'IX_Orders_Ship_City"'          "$migration" "property-level index on the complex column"
+assert_contains 'IX_Orders_Ship_City_Ship_Zip'  "$migration" "entity-level composite index"
+assert_contains 'Ship_City'                     "$migration" "complex property resolved to its real column name"
+
+# The phantom-churn guard. A second `migrations add` against an unchanged model must scaffold
+# nothing: if the snapshot and the code model disagree, the indexes are dropped and recreated on
+# every single migration, which applies cleanly and is therefore invisible without this check.
+echo "==> dotnet ef migrations add NoChanges (must be empty)"
+dotnet tool run dotnet-ef migrations add NoChanges >/dev/null
+second="$(find Migrations -name '*_NoChanges.cs' | head -1)"
+
+if grep -qE 'migrationBuilder\.(CreateIndex|DropIndex|Sql|AddColumn|CreateTable)' "$second"; then
+    echo "  FAIL: re-running migrations add produced operations — the model churns"
+    grep -E 'migrationBuilder\.' "$second" | sed 's/^/      /'
+    failed=1
+else
+    echo "  ok: no churn on an unchanged model"
+fi
+
+[[ $failed -eq 0 ]] || { echo; echo "consumer smoke test FAILED"; exit 1; }
+echo
+echo "consumer smoke test passed ($version)"


### PR DESCRIPTION
Closes the biggest remaining coverage gap: nothing exercised the delivery chain a real consumer takes.

## `test/consumer-smoke-test.sh`

Packs the nupkgs, restores them into a throwaway project **outside** the repository, and runs a real `dotnet ef migrations add` — then asserts on the scaffolded content.

Asserting on content rather than exit code is the whole point. With both `.targets` neutered, `dotnet ef migrations add` still succeeds and scaffolds the table and columns; the indexes silently vanish. That is the failure mode this repo exists to catch, and it is invisible to an exit-code check.

Also asserts a second `migrations add` on an unchanged model scaffolds nothing, which guards the phantom-churn class of bug end to end.

Wired into both workflows: every PR, and the release workflow against the packed artifacts themselves.

## NU1903

Documented rather than fixed. The vulnerable package arrives only via `Microsoft.EntityFrameworkCore.Design` (`PrivateAssets=all`), so consumers never restore it. Bumping Design clears it but forces the consumer EF Core floor from 10.0.0 to 10.0.11 via NU1605.

## Verification

- Guard verified by sabotage: passes clean, exits 1 with both `.targets` neutered
- An early draft of the script passed the sabotaged build — NuGet's global package cache was shadowing the local build. Fixed with a private `NUGET_PACKAGES`
- Unit suite: 179 passed