### PR TITLE
Cap the EF Core dependency below the next major

### DIFF
--- a/src/EFCore.ComplexIndexes.PostgreSQL/EFCore.ComplexIndexes.PostgreSQL.csproj
+++ b/src/EFCore.ComplexIndexes.PostgreSQL/EFCore.ComplexIndexes.PostgreSQL.csproj
@@ -19,7 +19,9 @@
 
     <ItemGroup>
         <ProjectReference Include="..\EFCore.ComplexIndexes\EFCore.ComplexIndexes.csproj" />
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
+        <!-- Ceiling for the same reason as the core package: this differ extends Npgsql's own
+             generator and diff internals, which carry no cross-major compatibility promise. -->
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="[10.0.0, 11.0.0)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/EFCore.ComplexIndexes.SqlServer/EFCore.ComplexIndexes.SqlServer.csproj
+++ b/src/EFCore.ComplexIndexes.SqlServer/EFCore.ComplexIndexes.SqlServer.csproj
@@ -19,7 +19,9 @@
 
     <ItemGroup>
         <ProjectReference Include="..\EFCore.ComplexIndexes\EFCore.ComplexIndexes.csproj" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" />
+        <!-- Ceiling for the same reason as the core package: the SQL Server differ extends EF
+             internals that carry no cross-major compatibility promise. -->
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="[10.0.0, 11.0.0)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/EFCore.ComplexIndexes/EFCore.ComplexIndexes.csproj
+++ b/src/EFCore.ComplexIndexes/EFCore.ComplexIndexes.csproj
@@ -11,8 +11,21 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 
+    <!--
+        The EF Core dependency is a range with an exclusive ceiling, not a floor.
+
+        This package subclasses MigrationsModelDiffer and calls EF1001-marked internals, which EF
+        documents as changeable or removable without notice in any release. An open-ended ">= 10.0.0"
+        lets NuGet resolve EF Core 11 for a consumer, where the differ can break at design time — and
+        it breaks in someone else's `dotnet ef` run, not anywhere visible from here. Npgsql's own
+        provider declares [x, 11.0.0) for the same reason.
+
+        The lower bound stays at 10.0.0 so consumers are not forced onto a newer servicing patch;
+        NuGet picks the lowest version in a range, so this changes nothing for anyone on EF Core 10.
+        Lifting the ceiling is a deliberate act once the differ has been tested against the next major.
+    -->
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="10.0.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="[10.0.0, 11.0.0)" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>compile</IncludeAssets>


### PR DESCRIPTION
Closes the last item from the repository review.

`>= 10.0.0` with no ceiling let NuGet resolve EF Core 11 for a consumer. Since this package subclasses `MigrationsModelDiffer` and uses `EF1001` internals — explicitly changeable without notice in any release — that break would land in someone else's `dotnet ef` run and never be visible from here.

Matches what Npgsql.EntityFrameworkCore.PostgreSQL and EFCore.NamingConventions declare.

| Package | Before | After |
|---|---|---|
| EFCore.ComplexIndexes | `Abstractions >= 10.0.0` | `Abstractions [10.0.0, 11.0.0)` |
| …PostgreSQL | `Npgsql.EFCore.PostgreSQL >= 10.0.0` | `[10.0.0, 11.0.0)` |
| …SqlServer | `EFCore.SqlServer >= 10.0.0` | `[10.0.0, 11.0.0)` |

No change for existing consumers: NuGet resolves the lowest version in a range, so restore still picks 10.0.0.

## Verification

- Packed nuspecs confirmed to carry the ranges
- `dotnet list package` confirms resolution still lands on 10.0.0
- 186 tests pass, consumer smoke test passes against the bounded packages