### PR TITLE
Move the artifact actions onto the Node 24 runtime

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -66,7 +66,7 @@ jobs:
           --results-directory TestResults
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: test-results-${{ matrix.os }}
@@ -103,7 +103,7 @@ jobs:
           --results-directory TestResults
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: test-results-integration
@@ -169,7 +169,7 @@ jobs:
           done
 
       - name: Upload packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: nupkg
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,8 +157,13 @@ jobs:
           printf 'Packages (%d):\n' "${#packages[@]}"
           printf '    %s\n' "${packages[@]##*/}"
 
+      # upload-artifact v6 and download-artifact v7 are the majors that actually switched to the
+      # Node 24 runtime; v5/v6 respectively only had preliminary support and still ran on Node 20,
+      # which the runner now warns about. Deliberately not the newest majors: upload v7 adds ESM and
+      # direct (unzipped) uploads, and download v8 turns a digest mismatch into a hard failure and
+      # stops auto-unzipping. Neither buys anything here, and this is the publish path.
       - name: Upload packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: nupkg-${{ steps.version.outputs.version }}
           path: |
@@ -189,7 +194,7 @@ jobs:
 
       # Publishes exactly what was verified — the packages are not rebuilt here.
       - name: Download packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: nupkg-${{ needs.verify.outputs.version }}
           path: dist


### PR DESCRIPTION
Clears the `Node.js 20 is deprecated` warnings seen on the macOS runs (and on the release run).

There is no Node version to set here — no workflow installs Node. The runtime is baked into each action, so the fix is the action major.

| Action | Before | After | Why |
|---|---|---|---|
| `actions/upload-artifact` | v4 (node20) | **v6** (node24) | v5 was preliminary support, still defaulted to node20 |
| `actions/download-artifact` | v4 (node20) | **v7** (node24) | v6 was preliminary support, still defaulted to node20 |
| `actions/checkout` | v6 | unchanged | already node24 |
| `actions/setup-dotnet` | v5 | unchanged | already node24 |
| `NuGet/login` | v1 | unchanged | already node24 |

Runtimes verified by reading `action.yml` at each pinned tag, not by assuming from the version number.

### Not taking the newest majors

- `upload-artifact@v7` — ESM plus direct unzipped uploads
- `download-artifact@v8` — **breaking**: digest mismatch becomes a hard failure, and non-zipped downloads are no longer auto-unzipped

Neither buys anything here, and both sit on the publish path. Rationale is in a comment in `release.yml` so a future bump is a decision rather than a reflex.