### PR TITLE
Release 5.0.3

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>5.0.2</Version>
+        <Version>5.0.3</Version>
         <Authors>CaffeinatedCoder</Authors>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/README.md
+++ b/README.md
@@ -515,6 +515,14 @@ expression-index DDL — model a persisted computed column and index that) and
 
 ---
 
+## What changed in 5.0.3
+
+A packaging and documentation release. No behaviour changes to the differ or the generated SQL.
+
+- **Changed:** the EF Core dependency now declares an exclusive upper bound — `[10.0.0, 11.0.0)` on `Microsoft.EntityFrameworkCore.Abstractions` for the core package, and on the provider package for each satellite. This package subclasses `MigrationsModelDiffer` and calls internals EF marks as changeable without notice in any release, so an open-ended `>= 10.0.0` let NuGet resolve a future major where the differ can break — surfacing as a confusing `dotnet ef` failure in your project rather than anywhere visible from here. **Nothing changes for existing consumers:** NuGet resolves the lowest version in a range, so restore still picks 10.0.0. Adopting EF Core 11 will need a release that lifts the ceiling deliberately, once the differ has been tested against it.
+- **New:** the public API is now fully documented, so IntelliSense no longer comes up empty on the fluent API, the annotation keys, `CompositeIndexDefinition`, or `IndexPartDefinition`. The shipped `.xml` had 64 holes in it; `TreatWarningsAsErrors` now keeps it complete.
+- **Tests:** a consumer smoke test runs on every PR and on release. It packs the packages, installs them into a throwaway project created outside this repository, and runs a real `dotnet ef migrations add` — then asserts on the scaffolded content, because the failure it guards against is a migration that succeeds while silently omitting every index. Nothing previously exercised the delivery chain end to end: NuGet restore, the packaged `.targets` injecting the design-time attribute, EF's host discovering it, and the right differ winning.
+
 ## What changed in 5.0.2
 
 A review of the 5.0.1 tree turned up eleven issues. The first three produced migrations that

--- a/src/EFCore.ComplexIndexes.PostgreSQL/README.md
+++ b/src/EFCore.ComplexIndexes.PostgreSQL/README.md
@@ -149,6 +149,15 @@ explicit control or `SuppressTemporalExtensionAutoInjection()` to opt out.
 
 ## Changelog
 
+### 5.0.3
+
+- **Changed:** the `Npgsql.EntityFrameworkCore.PostgreSQL` dependency is now `[10.0.0, 11.0.0)`. This
+  differ extends Npgsql's own diff and generator internals, which carry no cross-major compatibility
+  promise. Nothing changes if you are on Npgsql 10: NuGet resolves the lowest version in a range.
+- **New:** the public API is fully documented, including the differ and the custom SQL generator.
+- **Tests:** the consumer smoke test scaffolds a real migration from this package as installed from a
+  NuGet feed, which is what verifies that the packaged `.targets` still registers the Npgsql differ.
+
 ### 5.0.2
 
 - **Fixed:** temporal `UNIQUE … WITHOUT OVERLAPS` constraints and temporal foreign keys are rendered

--- a/src/EFCore.ComplexIndexes.SqlServer/README.md
+++ b/src/EFCore.ComplexIndexes.SqlServer/README.md
@@ -62,6 +62,13 @@ rather than producing DDL that cannot apply:
 
 ## Changelog
 
+### 5.0.3
+
+- **Changed:** the `Microsoft.EntityFrameworkCore.SqlServer` dependency is now `[10.0.0, 11.0.0)`.
+  This differ extends EF internals that carry no cross-major compatibility promise. Nothing changes
+  if you are on EF Core 10: NuGet resolves the lowest version in a range.
+- **New:** the public API is fully documented.
+
 ### 5.0.2
 
 - **Fixed:** clustered-index combinations SQL Server rejects are caught at `migrations add`

--- a/src/EFCore.ComplexIndexes/README.md
+++ b/src/EFCore.ComplexIndexes/README.md
@@ -81,6 +81,21 @@ see the PostgreSQL package.
 
 ## Changelog
 
+### 5.0.3
+
+- **Changed:** the `Microsoft.EntityFrameworkCore.Abstractions` dependency is now `[10.0.0, 11.0.0)`.
+  This package subclasses `MigrationsModelDiffer` and calls internals EF marks as changeable without
+  notice in any release, so an open-ended floor let NuGet resolve a future major where the differ can
+  break — in your `dotnet ef` run, not anywhere visible from here. Nothing changes if you are on EF
+  Core 10: NuGet resolves the lowest version in a range, so restore still picks 10.0.0.
+- **New:** the public API is fully documented. The shipped `.xml` had 64 gaps, so IntelliSense came up
+  empty on parts of the fluent API, the annotation keys, `CompositeIndexDefinition` and
+  `IndexPartDefinition`.
+- **Tests:** a consumer smoke test packs the packages, installs them into a throwaway project outside
+  the repository, and runs a real `dotnet ef migrations add`, asserting on the scaffolded content —
+  the delivery chain (restore, `.targets` injection, design-time discovery, differ selection) was
+  previously only ever verified in pieces.
+
 ### 5.0.2
 
 - **Fixed:** the design-time migration differ is now selected deterministically when a provider


### PR DESCRIPTION
Packaging and documentation release. **No behaviour changes** to the differ or the generated SQL.

## Contents

| | |
|---|---|
| **Changed** | EF Core dependencies now declare `[10.0.0, 11.0.0)` |
| **New** | Public API fully documented — the shipped `.xml` had 64 gaps |
| **Tests** | Consumer smoke test covering restore → `.targets` → design-time discovery → `dotnet ef migrations add` |

Version bumped in `Directory.Build.props`; changelog sections added to all four READMEs, each package listing only what applies to it.

## Note for consumers

The upper bound changes nothing for anyone on EF Core 10 — NuGet resolves the lowest version in a range, so restore still picks 10.0.0. It does mean EF Core 11 will require a release that lifts the ceiling deliberately, after the differ has been tested against it.

## Verification

- `ChangelogConsistencyTests`: 4/4
- Full suite: 186 passed
- Pack produces all six files at 5.0.3
- Consumer smoke test passes against the 5.0.3 packages

## After merge

```
git checkout main && git pull --ff-only
git tag v5.0.3 && git push origin v5.0.3
```

The release workflow verifies the tag against `Directory.Build.props`, runs the full suite plus the smoke test against the packed artifacts, then waits for approval before anything reaches nuget.org.