### PR TITLE
Exercise the smoke test's feed mode on pull requests

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -155,6 +155,15 @@ jobs:
             unzip -l "$package" | awk '{ print "    " $NF }' | grep -E 'README|targets|\.dll$' || true
           done
 
+      # The smoke test's *other* invocation mode. The `consumer` job runs it with no argument, where
+      # it packs its own feed; here it is handed a pre-built one, exactly as the release workflow
+      # does. The two are not interchangeable — packing pre-populates NUGET_PACKAGES with the
+      # solution's dependencies, and a restore that only works because of that side effect passes
+      # one way and fails the other. That difference broke a release, because until now nothing
+      # exercised this mode before release day.
+      - name: Consumer smoke test against the packed feed
+        run: ./test/consumer-smoke-test.sh dist
+
       # Generating here too means a broken SBOM step surfaces on a PR rather than on release day.
       - name: Generate SBOMs
         run: |


### PR DESCRIPTION
The consumer smoke test has two invocation modes, and only one ran before release day.

| Mode | Ran in | Now |
|---|---|---|
| Self-packing (`consumer-smoke-test.sh`) | `consumer` job, every PR | unchanged |
| Pre-built feed (`consumer-smoke-test.sh dist`) | **release only** | also the `pack` job, every PR |

They are not interchangeable: packing pre-populates `NUGET_PACKAGES` with the solution's dependencies, so a restore that only works because of that side effect passes one way and fails the other. That is precisely what broke the first `v5.0.3` tag — the approval gate was the only thing between it and a bad publish.

The `pack` job already produces a `dist`, so this is one extra step. Placed before the SBOM step so the feed holds only packages, matching `release.yml`.

## Verification

Simulated the pack job exactly — wiped all build output, cold `dotnet pack -c Release -o dist`, then the feed-mode smoke test. Passes.