### PR TITLE
Pin each satellite in the consumer smoke test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,15 +91,29 @@ throwaway project created **outside the repository** (inside it, `Directory.Buil
 and the project would stop resembling a consumer's), and runs a real `dotnet ef migrations add`. It
 then asserts on scaffolded content — never on the exit code, because the failure being hunted is a
 `migrations add` that succeeds while silently omitting every index. Neutering both `.targets` files
-reproduces exactly that: table and columns scaffold fine, indexes vanish, exit code 0.
+reproduces exactly that: table and columns scaffold fine, indexes vanish, exit code 0. One consumer
+project per satellite; it runs on every PR in both of its invocation modes (the `consumer` job packs
+its own feed, the `pack` job passes the one it just built, as the release workflow does).
 
-Two things in it are load-bearing and easy to "simplify" away. `NUGET_PACKAGES` is redirected to a
+**Index options do not prove which differ ran.** Entity-level provider annotations reach the
+operation unfiltered, so the core differ emits `Npgsql:IndexMethod` and `SqlServer:FillFactor` just
+as the satellites do — a neutered satellite `.targets` still yields a migration that looks right,
+because the core registration rides along through `buildTransitive` and covers it. Each provider is
+therefore pinned by something only its own differ does: PostgreSQL by an exclusion constraint, whose
+design-time DDL the core differ has never heard of, and SQL Server by a *rejection* — a clustered
+complex index must fail at `migrations add`, and scaffolding cleanly is the failure. Both were
+confirmed by neutering each satellite's `.targets` in turn; the index assertions kept passing, which
+is precisely the point.
+
+Two more things are load-bearing and easy to "simplify" away. `NUGET_PACKAGES` is redirected to a
 private folder because NuGet resolves id+version from the global packages folder before consulting
-any source — with the version pinned at 5.0.2 a locally built package is shadowed by whatever 5.0.2
+any source — a locally built package is otherwise shadowed by whatever build of that same version
 was restored before, up to and including the one on nuget.org, and the test silently reports on the
-wrong artifact. And `<clear/>` in the generated `nuget.config` stops nuget.org from satisfying the
-restore on its own. Note also that the two `.targets` are *redundant* by design: sabotaging either
-one alone still yields correct migrations, because the surviving registration covers it.
+wrong artifact. And the generated `nuget.config` uses **package source mapping**, not source order:
+this repository's own ids must come from the local feed and nothing else, while every transitive
+dependency must come from nuget.org. Restricting the whole restore to the local feed instead (the
+`--source` flag) fails with NU1101, and it fails only when a feed is passed in, because packing
+first happens to populate the private cache — which is how it reached a release.
 
 **`MigrationHarness`** (under `test/…/Harness/`) is the shared rig: build a model from a
 `DbContext`, construct any differ, render operations through either the stock provider generator or

--- a/test/consumer-smoke-test.sh
+++ b/test/consumer-smoke-test.sh
@@ -11,8 +11,12 @@
 # silently: `migrations add` still succeeds, it just quietly omits the indexes. So the assertions
 # here are about scaffolded *content*, never about the exit code alone.
 #
-# The consumer project is created outside the repository on purpose. Inside it, Directory.Build.props
-# would apply and the project would stop resembling anything a consumer builds.
+# Both satellites are covered, in separate consumer projects. The SQL Server one is not redundant:
+# ForProvider scoping means EF skips a satellite whose provider does not match, so a typo there
+# leaves SQL Server consumers with no differ at all — and nothing else would notice.
+#
+# The consumer projects are created outside the repository on purpose. Inside it,
+# Directory.Build.props would apply and they would stop resembling anything a consumer builds.
 #
 # Usage: consumer-smoke-test.sh [feed-directory]
 #   With no argument the packages are packed fresh. Pass a directory of existing .nupkg files
@@ -24,13 +28,13 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
 
-app="$work/app"
 feed="${1:-}"
+failed=0
 
 # A private package cache, and not an optimisation to skip.
 #
 # NuGet resolves id+version from the global packages folder before it ever looks at a source, so with
-# the version number held at 5.0.2 a locally built package is shadowed by whatever 5.0.2 was restored
+# the version number held at 5.0.3 a locally built package is shadowed by whatever 5.0.3 was restored
 # before — including the one published on nuget.org. The test then reports on a package that has
 # nothing to do with the working tree. It passed a deliberately sabotaged build that way.
 export NUGET_PACKAGES="$work/packages"
@@ -49,21 +53,47 @@ fi
 
 ls "$feed"/EFCore.ComplexIndexes."$version".nupkg >/dev/null
 
-echo "==> Creating a consumer project at $app"
-mkdir -p "$app"
-cd "$app"
-dotnet new console --framework net10.0 --output . --verbosity quiet >/dev/null
+# Quiet while it works, but never silent when it does not: swallowing this output once hid an
+# NU1101 behind a bare "exit code 1" in CI.
+run() {
+    if ! output="$("$@" 2>&1)"; then
+        echo "FAILED: $*"
+        echo "$output" | sed 's/^/    /'
+        exit 1
+    fi
+}
 
-# Source mapping, not just source ordering.
+assert_contains() {
+    if grep -q "$1" "$2"; then
+        echo "  ok: $3"
+    else
+        echo "  FAIL: $3 (expected '$1' in $(basename "$2"))"
+        failed=1
+    fi
+}
+
+# One tool install shared by both consumers; the per-project alternative downloads it twice.
+run dotnet tool install dotnet-ef --version "10.*" --tool-path "$work/tools"
+export PATH="$work/tools:$PATH"
+
+# Creates a consumer project and installs the satellite. Program.cs is written by the caller
+# beforehand, at $work/<name>.cs.
 #
-# This package's own ids must come from the local feed and nowhere else — the versions here also
-# exist on nuget.org, and a published 5.0.2 satisfying the restore would mean testing a package that
-# has nothing to do with the working tree. Everything else (EF Core, Npgsql) has to come from
-# nuget.org, so restricting the restore to the local feed is not an option either: that fails with
-# NU1101 on the transitive dependencies.
-#
-# <clear/> drops any machine-level sources that would otherwise be consulted.
-cat > nuget.config <<XML
+# Source mapping, not just source ordering: this package's own ids must come from the local feed and
+# nowhere else, because these versions also exist on nuget.org and a published one satisfying the
+# restore would mean testing something unrelated to the working tree. Everything else (EF Core,
+# Npgsql) has to come from nuget.org, so restricting the whole restore to the local feed is not an
+# option either — that fails with NU1101 on the transitive dependencies. <clear/> drops any
+# machine-level sources.
+scaffold_consumer() {
+    local name="$1" package="$2" app="$work/$1"
+
+    echo "==> $name: consumer project, $package"
+    mkdir -p "$app"
+    cd "$app"
+    run dotnet new console --framework net10.0 --output .
+
+    cat > nuget.config <<XML
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
@@ -82,8 +112,121 @@ cat > nuget.config <<XML
 </configuration>
 XML
 
-cat > Program.cs <<'CSHARP'
+    cp "$work/$name.cs" Program.cs
+
+    # No --source flag: it would override the mapping above and restrict the whole restore,
+    # transitive dependencies included, to the local feed.
+    run dotnet add package "$package" --version "$version"
+    run dotnet add package Microsoft.EntityFrameworkCore.Design
+
+    # Built explicitly first: `dotnet ef` reports a compile error only as "Build failed. Use dotnet
+    # build to see the errors", which in CI is indistinguishable from the design-time host failing.
+    run dotnet build
+
+    echo "==> $name: dotnet ef migrations add Initial"
+    run dotnet-ef migrations add Initial
+}
+
+# A second `migrations add` against an unchanged model must scaffold nothing. If the snapshot and the
+# code model disagree, the indexes are dropped and recreated on every migration — which applies
+# cleanly and is therefore invisible without this check.
+assert_no_churn() {
+    local name="$1"
+    cd "$work/$1"
+    run dotnet-ef migrations add NoChanges
+    local second
+    second="$(find Migrations -name '*_NoChanges.cs' | head -1)"
+
+    if grep -qE 'migrationBuilder\.(CreateIndex|DropIndex|Sql|AddColumn|CreateTable)' "$second"; then
+        echo "  FAIL: $name re-running migrations add produced operations — the model churns"
+        grep -E 'migrationBuilder\.' "$second" | sed 's/^/      /'
+        failed=1
+    else
+        echo "  ok: no churn on an unchanged model"
+    fi
+}
+
+migration_of() {
+    find "$work/$1/Migrations" -name '*_Initial.cs' | head -1
+}
+
+# ── PostgreSQL ────────────────────────────────────────────────────────────────────────────────────
+
+cat > "$work/postgres.cs" <<'CSHARP'
 using EFCore.ComplexIndexes;
+using EFCore.ComplexIndexes.PostgreSQL;
+using Microsoft.EntityFrameworkCore;
+using NpgsqlTypes;
+
+Console.WriteLine("consumer");
+
+public sealed class Address
+{
+    public string City    { get; set; } = "";
+    public string Zip     { get; set; } = "";
+    public string Country { get; set; } = "";
+}
+
+public sealed class Order
+{
+    public int                    Id     { get; set; }
+    public Address                Ship   { get; set; } = new();
+    public NpgsqlRange<DateTime>  Period { get; set; }
+}
+
+public sealed class ShopContext : DbContext
+{
+    public DbSet<Order> Orders => Set<Order>();
+
+    protected override void OnConfiguring(DbContextOptionsBuilder options)
+        => options.UseNpgsql("Host=localhost;Database=smoke");
+
+    protected override void OnModelCreating(ModelBuilder model)
+    {
+        model.Entity<Order>(entity =>
+        {
+            entity.ComplexProperty(o => o.Ship, ship => ship.Property(a => a.City).HasComplexIndex());
+            entity.HasComplexCompositeIndex(o => new { o.Ship.City, o.Ship.Zip });
+
+            // Provider-specific rendering: reaches the operation as a real Npgsql annotation.
+            entity.HasComplexIndex(o => o.Ship.Zip, index => index.UseGin());
+
+            // Null ordering has no slot on EF's CreateIndexOperation, so it routes through the parts
+            // annotation and carries the sentinel that makes a missing runtime wiring fail loudly.
+            entity.HasComplexIndex(o => DbOrder.NullsLast(o.Ship.Country));
+
+            // The discriminator for "the Npgsql differ is the one that ran". Index options are not:
+            // entity-level provider annotations reach the operation unfiltered, so the core differ
+            // emits those too. Exclusion constraints are rendered as design-time DDL by the Npgsql
+            // differ alone — the core differ has never heard of them.
+            entity.HasExclusionConstraint(o => o.Ship.City, o => o.Period, name: "ex_orders_city_period");
+        });
+    }
+}
+CSHARP
+
+scaffold_consumer postgres EFCore.ComplexIndexes.PostgreSQL
+
+echo "==> postgres: asserting the scaffolded migration"
+pg="$(migration_of postgres)"
+[[ -n "$pg" ]] || { echo "FAIL: no migration was scaffolded"; exit 1; }
+
+assert_contains 'IX_Orders_Ship_City"'         "$pg" "property-level index on the complex column"
+assert_contains 'IX_Orders_Ship_City_Ship_Zip' "$pg" "entity-level composite index"
+assert_contains 'Ship_City'                    "$pg" "complex property resolved to its real column name"
+assert_contains 'Npgsql:IndexMethod'           "$pg" "provider option forwarded as an Npgsql annotation"
+assert_contains 'gin'                          "$pg" "the GIN index method survives packaging"
+assert_contains '__requires_UseNpgsqlComplexIndexes__' "$pg" "null-ordered index carries the runtime-wiring sentinel"
+assert_contains 'EXCLUDE'                      "$pg" "exclusion constraint DDL — only the Npgsql differ emits this"
+assert_contains 'ex_orders_city_period'        "$pg" "the exclusion constraint keeps its declared name"
+
+assert_no_churn postgres
+
+# ── SQL Server ────────────────────────────────────────────────────────────────────────────────────
+
+cat > "$work/sqlserver.cs" <<'CSHARP'
+using EFCore.ComplexIndexes;
+using EFCore.ComplexIndexes.SqlServer;
 using Microsoft.EntityFrameworkCore;
 
 Console.WriteLine("consumer");
@@ -105,71 +248,54 @@ public sealed class ShopContext : DbContext
     public DbSet<Order> Orders => Set<Order>();
 
     protected override void OnConfiguring(DbContextOptionsBuilder options)
-        => options.UseNpgsql("Host=localhost;Database=smoke");
+        => options.UseSqlServer("Server=localhost;Database=smoke;Trusted_Connection=True;TrustServerCertificate=True");
 
     protected override void OnModelCreating(ModelBuilder model)
     {
         model.Entity<Order>(entity =>
         {
             entity.ComplexProperty(o => o.Ship, ship => ship.Property(a => a.City).HasComplexIndex());
-            entity.HasComplexCompositeIndex(o => new { o.Ship.City, o.Ship.Zip });
+
+            // Provider-specific rendering. Deliberately not clustered: the SQL Server differ rejects
+            // a clustered complex index when the primary key already holds the clustered slot.
+            entity.HasComplexIndex(o => o.Ship.Zip, index => index.HasFillFactor(80).IsCreatedOnline());
         });
     }
 }
 CSHARP
 
-# Quiet while it works, but never silent when it does not: swallowing this output once hid an
-# NU1101 behind a bare "exit code 1" in CI. No --source flag here — that would override the source
-# mapping above and restrict the whole restore, transitive dependencies included, to the local feed.
-run() {
-    if ! output="$("$@" 2>&1)"; then
-        echo "FAILED: $*"
-        echo "$output" | sed 's/^/    /'
-        exit 1
-    fi
-}
+scaffold_consumer sqlserver EFCore.ComplexIndexes.SqlServer
 
-echo "==> Restoring the packed satellite from the local feed"
-run dotnet add package EFCore.ComplexIndexes.PostgreSQL --version "$version"
-run dotnet add package Microsoft.EntityFrameworkCore.Design
+echo "==> sqlserver: asserting the scaffolded migration"
+ss="$(migration_of sqlserver)"
+[[ -n "$ss" ]] || { echo "FAIL: no migration was scaffolded"; exit 1; }
 
-run dotnet new tool-manifest
-run dotnet tool install dotnet-ef --version "10.*"
+assert_contains 'IX_Orders_Ship_City"' "$ss" "property-level index on the complex column"
+assert_contains 'Ship_Zip'             "$ss" "complex property resolved to its real column name"
+assert_contains 'SqlServer:FillFactor' "$ss" "provider option forwarded as a SQL Server annotation"
+assert_contains 'SqlServer:Online'     "$ss" "second provider option on the same index"
 
-echo "==> dotnet ef migrations add Initial"
-run dotnet tool run dotnet-ef migrations add Initial
+assert_no_churn sqlserver
 
-migration="$(find Migrations -name '*_Initial.cs' | head -1)"
-[[ -n "$migration" ]] || { echo "FAIL: no migration was scaffolded"; exit 1; }
+# The discriminator for "the SQL Server differ is the one that ran". Index options are not: they
+# reach the operation unfiltered and the core differ emits them just the same, so a neutered
+# satellite .targets still produces a migration that looks correct. What only this satellite does is
+# *refuse* — a clustered complex index is rejected because the primary key already holds the
+# clustered slot. If the satellite is not registered, the declaration scaffolds silently instead.
+echo "==> sqlserver: a rejection only this satellite's differ performs"
+cd "$work/sqlserver"
+sed 's/index.HasFillFactor(80).IsCreatedOnline()/index.IsClustered()/' Program.cs > Program.cs.tmp
+mv Program.cs.tmp Program.cs
 
-failed=0
-assert_contains() {
-    if grep -q "$1" "$2"; then
-        echo "  ok: $3"
-    else
-        echo "  FAIL: $3 (expected '$1' in $(basename "$2"))"
-        failed=1
-    fi
-}
-
-echo "==> Asserting the scaffolded migration"
-assert_contains 'IX_Orders_Ship_City"'          "$migration" "property-level index on the complex column"
-assert_contains 'IX_Orders_Ship_City_Ship_Zip'  "$migration" "entity-level composite index"
-assert_contains 'Ship_City'                     "$migration" "complex property resolved to its real column name"
-
-# The phantom-churn guard. A second `migrations add` against an unchanged model must scaffold
-# nothing: if the snapshot and the code model disagree, the indexes are dropped and recreated on
-# every single migration, which applies cleanly and is therefore invisible without this check.
-echo "==> dotnet ef migrations add NoChanges (must be empty)"
-run dotnet tool run dotnet-ef migrations add NoChanges
-second="$(find Migrations -name '*_NoChanges.cs' | head -1)"
-
-if grep -qE 'migrationBuilder\.(CreateIndex|DropIndex|Sql|AddColumn|CreateTable)' "$second"; then
-    echo "  FAIL: re-running migrations add produced operations — the model churns"
-    grep -E 'migrationBuilder\.' "$second" | sed 's/^/      /'
+if reject_output="$(dotnet-ef migrations add Clustered 2>&1)"; then
+    echo "  FAIL: a clustered complex index scaffolded cleanly — the SQL Server differ did not run"
     failed=1
+elif grep -qi "clustered" <<<"$reject_output"; then
+    echo "  ok: clustered complex index rejected at migrations add"
 else
-    echo "  ok: no churn on an unchanged model"
+    echo "  FAIL: migrations add failed, but not with the clustered-index rejection:"
+    echo "$reject_output" | tail -5 | sed 's/^/      /'
+    failed=1
 fi
 
 [[ $failed -eq 0 ]] || { echo; echo "consumer smoke test FAILED"; exit 1; }


### PR DESCRIPTION
Closes the last gap from the repository review: the smoke test covered only core complex indexes, so a provider-specific regression passed it.

## The obvious fix does not work

Asserting on provider index options (`Npgsql:IndexMethod`, `SqlServer:FillFactor`) proves nothing. Entity-level provider annotations reach the operation **unfiltered**, so the core differ emits them too — and the core registration rides along through `buildTransitive`, so a neutered satellite `.targets` still yields a migration that looks correct.

I found this by sabotage, not by reasoning: the first version of this change **passed against a build with the SQL Server `.targets` neutered**.

## What actually pins each satellite

| Provider | Discriminator | Why only that differ |
|---|---|---|
| PostgreSQL | an exclusion constraint | rendered as design-time DDL; the core differ has never heard of `CustomExclusion:Constraints` |
| SQL Server | a **rejection** | a clustered complex index must fail at `migrations add`; scaffolding cleanly *is* the failure |

The SQL Server one is the only assertion in the suite that fails by succeeding.

## Also in here

- A second consumer project for the SQL Server satellite, which had **no** end-to-end coverage — a wrong `ForProvider` would have left its users with no differ at all
- GIN forwarding and the runtime-wiring sentinel on a null-ordered index
- Consumers built explicitly before scaffolding, because `dotnet ef` reports a compile error only as `Build failed`, which in CI is indistinguishable from the design-time host failing
- One shared `dotnet-ef` install instead of one per project
- CLAUDE.md corrected — the `nuget.config` description still credited `<clear/>` for what package source mapping now does

## Verification

Neutered each satellite's `.targets` in turn. Each fails **its own** discriminator; the index assertions keep passing, which is the point.

Suite: 191 passed. Both smoke-test invocation modes pass.