### PR TITLE
ci: run the unit suite on Linux only

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,7 +1,7 @@
 # Build and test on every push to main and every PR.
 #
-# Split into two jobs on purpose: the unit suite runs on all three runner OSes, while the
-# integration suite needs Docker and so runs only on Linux.
+# Split into two jobs on purpose: the unit suite and the integration suite, the latter needing
+# Docker for its PostgreSQL container.
 #
 # For information on GitHub Actions with .NET, see:
 # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
@@ -36,10 +36,14 @@ jobs:
   test:
     name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    # Linux only. The matrix is kept as a single entry rather than flattened to a plain `runs-on`
+    # so the job keeps reporting as `Test (ubuntu-latest)` — that exact string is a required check
+    # in the branch protection rule on main, and a rename would leave it required and never
+    # reported, hanging PRs instead of failing them. Re-adding an OS is a one-line change here.
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ ubuntu-latest ]
 
     steps:
       - uses: actions/checkout@v6
@@ -55,9 +59,11 @@ jobs:
       - name: Build
         run: dotnet build -c Release --no-restore
 
-      # The matrix earns its keep here: the repository-convention tests do real path work
-      # (locating src/, reading .targets and README files), which is where separator handling
-      # differs between Windows and the Unix runners.
+      # This used to fan out across ubuntu/windows/macos for the repository-convention tests, which
+      # do real path work. Dropped as unearned: no shipped code touches the filesystem, so the only
+      # thing the other runners proved was that the *test harness* composes paths portably — which
+      # it does via Path.Combine, and which fails loudly on the machine of whoever hits it. Fix that
+      # reactively if a Windows contributor ever appears.
       - name: Unit tests
         run: >
           dotnet test -c Release --no-build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,11 +32,23 @@ the build reports green.
 
 ## CI
 
-`.github/workflows/dotnet.yml` runs on pushes and PRs to `main`: the unit suite across
-ubuntu/windows/macos (the matrix is there because the repository-convention tests do real path
-work), the integration suite on Linux only (Docker), then a pack job whose value is partly that
-packing *is* a check — a package declaring `PackageReadmeFile` without packing the file fails with
-NU5019.
+`.github/workflows/dotnet.yml` runs on pushes and PRs to `main`: the unit suite, the integration
+suite (Docker), then a pack job whose value is partly that packing *is* a check — a package
+declaring `PackageReadmeFile` without packing the file fails with NU5019. Everything runs on
+ubuntu-latest.
+
+The unit job used to fan out across ubuntu/windows/macos for the repository-convention tests, which
+do real path work. Dropped in favour of reacting if it ever bites: **no shipped code touches the
+filesystem** (the `Path`-looking code under `src/` splits dotted *property* paths), so the other
+runners only ever proved that the test harness composes paths portably. That is a contributor-
+environment property, not a package one, and it fails loudly on the machine of whoever hits it.
+Note what the matrix was *not* buying, in case it looks tempting to restore: whether the packaged
+`.targets` works under Windows MSBuild is still untested either way, since the smoke test is
+Linux-only and `PackagingConventionTests` reads the `.targets` rather than executing it.
+
+The job deliberately keeps a single-entry `matrix.os` rather than a plain `runs-on`, so it still
+reports as `Test (ubuntu-latest)` — a required check in branch protection, where a renamed job stays
+required, never reports, and hangs PRs instead of failing them.
 
 Both workflows generate a **CycloneDX SBOM per package** (`*.cdx.json`) alongside the nupkgs, via
 the `cyclonedx` tool pinned in `.config/dotnet-tools.json`. `--exclude-filter` drops


### PR DESCRIPTION
Trims the unit job's OS matrix from ubuntu/windows/macos down to ubuntu-latest.

## Why the other runners were unearned

No shipped code touches the filesystem — the `Path`-looking code under `src/` splits dotted *property* paths (`dotPath.Split('.')`), not file paths. All real path work lives in the test harness (`RepositoryLayout`) and the convention tests that use it, via `Path.Combine`.

So Windows and macOS only ever proved that the **test harness** composes paths portably. That is a contributor-environment property, not a package one, and it fails loudly and locally on the machine of whoever hits it — fixable when it happens.

Worth recording what the matrix was *not* buying, in case restoring it looks tempting: whether the packaged `.targets` works under Windows MSBuild is untested either way. `consumer-smoke-test.sh` is Linux-only, and `PackagingConventionTests` reads the `.targets` text rather than executing it.

## Why the matrix stays as a single entry

Flattening to a plain `runs-on: ubuntu-latest` renames the job to `Test`. `Test (ubuntu-latest)` is a required check on `main`, and a renamed job leaves the old name required while never reporting — PRs hang instead of failing. Re-adding an OS is a one-line change.

## Branch protection

Already updated ahead of this PR, so it isn't blocked by the jobs it deletes. Required checks are now `Test (ubuntu-latest)`, `Integration (PostgreSQL 18)`, `Consumer smoke test`, `Pack`.

`ClaudeMdConsistencyTests` passes against the updated `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)