### PR TITLE
test: pin SECURITY.md's supported-versions table to the shipped version

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,7 @@ below exist because ordinary review does not catch it.
 | `PackagingConventionTests` | Every package ships its own README as `PackageReadmeFile`; `.targets` ship to both `build/` and `buildTransitive/`, reference a real `IDesignTimeServices` in their own assembly, and set `ForProvider` on satellites but not on core. |
 | `ClaudeMdConsistencyTests` | This file. Prose cannot be asserted, so it checks the falsifiable parts: cited paths and file names exist, annotation keys under a prefix this repo owns are declared somewhere, `Type.Member` references resolve, and the stated size of the Npgsql whitelist matches it. Those are what a rename rots silently — and the count claim had already gone stale by two. |
 | `BuilderApiParityTests` | Every key in a satellite's annotation whitelist is reachable from a builder method. `SqlServer:DataCompression` sat whitelisted with no API for a full release; this catches that class of drift by invoking every builder extension and diffing the keys it sets. |
+| `SecurityPolicyConsistencyTests` | SECURITY.md's supported-versions table names the minor being shipped, and its `< x.y` row meets it. The table is prose a version bump forgets — the sibling repository shipped 6.2.0 with the table still saying 6.1.x. |
 
 **`test/consumer-smoke-test.sh`** is the only check that exercises *delivery* rather than code. Every
 other layer is verified in isolation and in-process; this one packs the nupkgs, restores them into a

--- a/test/EFCore.ComplexIndexes.Tests/SecurityPolicyConsistencyTests.cs
+++ b/test/EFCore.ComplexIndexes.Tests/SecurityPolicyConsistencyTests.cs
@@ -1,0 +1,69 @@
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+
+namespace EFCore.ComplexIndexes.Tests;
+
+/// <summary>
+/// SECURITY.md promises fixes for "the latest released minor version" and tabulates which line that
+/// is. The table is prose: nothing ties it to <c>Directory.Build.props</c>, so a release that bumps
+/// the version and forgets the table leaves the policy pointing a reporter at a line that no longer
+/// receives fixes. A supported-versions table that is wrong is worse than none — it reads as a
+/// considered statement — and it is exactly the kind of line a version bump forgets.
+/// </summary>
+[TestClass]
+public class SecurityPolicyConsistencyTests
+{
+    private static string SecurityPolicy => Path.Combine(RepositoryLayout.Root, "SECURITY.md");
+
+    // "| 5.0.x | ✅ |" — the one line that receives fixes.
+    private static readonly Regex SupportedRow =
+        new(@"^\|\s*(\d+)\.(\d+)\.x\s*\|\s*✅\s*\|", RegexOptions.Multiline | RegexOptions.Compiled);
+
+    // "| < 5.0 | ❌ |" — everything before it.
+    private static readonly Regex UnsupportedRow =
+        new(@"^\|\s*<\s*(\d+)\.(\d+)\s*\|\s*❌\s*\|", RegexOptions.Multiline | RegexOptions.Compiled);
+
+    private static Version PackageVersion =>
+        Version.Parse(XDocument.Load(RepositoryLayout.BuildProps)
+                               .Descendants("Version")
+                               .Single()
+                               .Value);
+
+    [TestMethod(DisplayName = "SECURITY.md's supported-versions table names the minor being shipped")]
+    public void Supported_versions_table_names_the_shipped_minor()
+    {
+        var text     = File.ReadAllText(SecurityPolicy);
+        var shipped  = PackageVersion;
+        var expected = $"{shipped.Major}.{shipped.Minor}";
+
+        var supported = SupportedRow.Matches(text);
+
+        Assert.HasCount(
+            1, supported,
+            "SECURITY.md should have exactly one '| x.y.x | ✅ |' row — the policy is that fixes land "
+          + "on the latest released minor only, so there is one supported line to name.");
+
+        var supportedLine = $"{supported[0].Groups[1].Value}.{supported[0].Groups[2].Value}";
+
+        Assert.AreEqual(
+            expected, supportedLine,
+            $"SECURITY.md lists {supportedLine}.x as the supported line, but Directory.Build.props ships "
+          + $"{shipped}. The table is part of the version bump: a reporter reads it to decide whether "
+          + "their version still receives fixes.");
+
+        var unsupported = UnsupportedRow.Match(text);
+
+        Assert.IsTrue(
+            unsupported.Success,
+            "SECURITY.md should have a '| < x.y | ❌ |' row saying that everything before the supported "
+          + "line is unmaintained.");
+
+        var unsupportedBelow = $"{unsupported.Groups[1].Value}.{unsupported.Groups[2].Value}";
+
+        Assert.AreEqual(
+            expected, unsupportedBelow,
+            $"SECURITY.md says versions below {unsupportedBelow} are unsupported, but the supported line "
+          + $"is {expected}.x — the two rows should meet at the same minor, or a range is left "
+          + "described by neither.");
+    }
+}


### PR DESCRIPTION
## Why

[SECURITY.md](SECURITY.md) promises fixes for "the latest released minor version" and tabulates which line that is. Nothing tied the table to `Directory.Build.props`, so it is exactly the line a version bump forgets — the sibling repository shipped 6.2.0 with its table still saying 6.1.x. Here it happens to be right (5.0.x, shipping 5.0.3). "Prefer a test to a convention."

## What

`SecurityPolicyConsistencyTests` asserts that the single `| x.y.x | ✅ |` row is the shipped major.minor, and that the `| < x.y | ❌ |` row meets it at the same minor (so no range is left described by neither). One row added to the convention-tests table in CLAUDE.md.

## Verified (verify-the-guard)

- Passes against the current table.
- Fails with the supported row changed to `5.1.x` ("SECURITY.md lists 5.1.x as the supported line, but Directory.Build.props ships 5.0.3").
- Fails with the unsupported row changed to `< 4.0`.
- Passes again once restored; `ClaudeMdConsistencyTests` passes with the new table row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
