### PR TITLE
test: guard PrivateAssets=all per shipping project

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,16 @@ declaring one, handing consumers vulnerability alerts for code they never receiv
 SBOM that misdescribes the package is worse than none. Publishing one is a courtesy: the CRA's SBOM
 duty falls on commercial consumers for their own products, not on this package.
 
+That filter test flattens the three projects into one set of ids, so it only ever asks whether a
+name is *somewhere* private; a second guard asserts a reference marked `PrivateAssets=all` in one
+project is marked so in **every** project. Dropping it from a single csproj is invisible to every
+other check — the package still builds, the SBOM test still passes — while that one nuspec starts
+declaring the dependency and its consumers restore the whole subtree behind it. That is what makes
+"consumers never receive it" true, and it is the premise `NU1903` staying a warning rests on
+(`Directory.Build.props`), along with the `System.Security.Cryptography.Xml` ignore under `src/` in
+`.github/dependabot.yml`. Confirmed by removing the metadata from one satellite: a consumer of the
+resulting package inherits all eight advisories.
+
 `.github/workflows/release.yml` publishes on a `v*` tag. `Directory.Build.props` stays the single
 source of truth: the tag is verified against it rather than driving it, packages are discovered from
 the pack output (so a future satellite needs no workflow edit), and pushes use `--skip-duplicate` so

--- a/test/EFCore.ComplexIndexes.Tests/PackagingConventionTests.cs
+++ b/test/EFCore.ComplexIndexes.Tests/PackagingConventionTests.cs
@@ -131,6 +131,51 @@ public class PackagingConventionTests
           + "consumers never receive.");
     }
 
+    [TestMethod(DisplayName = "A reference marked build-only in one project is build-only in every project")]
+    public void Build_only_references_are_private_in_every_project()
+    {
+        // The test above flattens all three projects into one set of ids, so it only ever asks
+        // whether a name is *somewhere* private. Drop PrivateAssets=all from a single csproj and the
+        // other two keep that name in the set: the SBOM test stays green while that one package's
+        // nuspec starts declaring the dependency, and its consumers restore the whole subtree behind
+        // it. For Microsoft.EntityFrameworkCore.Design that is ~45 MSBuild/Roslyn components — and
+        // "consumers never receive it" is the stated reason NU1903 stays a warning
+        // (Directory.Build.props) and the reason .github/dependabot.yml ignores
+        // System.Security.Cryptography.Xml under src/. Nothing else checks it per project.
+        var references = Projects
+                        .Select(project => (
+                             project,
+                             refs: XDocument.Load(project.ProjectFile)
+                                            .Descendants("PackageReference")
+                                            .Where(reference => reference.Attribute("Include") is not null)
+                                            .Select(reference => (Id: reference.Attribute("Include")!.Value,
+                                                                  IsBuildOnly: IsPrivate(reference)))
+                                            .ToList()))
+                        .ToList();
+
+        var buildOnly = references.SelectMany(entry => entry.refs)
+                                  .Where(reference => reference.IsBuildOnly)
+                                  .Select(reference => reference.Id)
+                                  .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        Assert.IsNotEmpty(buildOnly, "Expected at least one PrivateAssets=all reference — has the packaging changed?");
+
+        var shipped = references
+                     .SelectMany(entry => entry.refs
+                                               .Where(reference => !reference.IsBuildOnly && buildOnly.Contains(reference.Id))
+                                               .Select(reference => $"{entry.project} -> {reference.Id}"))
+                     .OrderBy(entry => entry, StringComparer.Ordinal)
+                     .ToList();
+
+        Assert.IsEmpty(
+            shipped,
+            $"{string.Join("; ", shipped)} — marked PrivateAssets=all elsewhere under src/ but not here, "
+          + "so this package's nuspec declares it and its consumers restore that dependency's entire "
+          + "subtree. Mark it PrivateAssets=all here too; if a consumer genuinely needs it at runtime, "
+          + "make it public in every project and drop it from the SBOM --exclude-filter, because it is "
+          + "then a dependency they really do take on.");
+    }
+
     /// <summary>
     /// Package validation compares each pack against <c>PackageValidationBaselineVersion</c>. A
     /// baseline left behind stops seeing API added since it — a member introduced in 5.1 and


### PR DESCRIPTION
## Why

Triaging the 32 open Dependabot alerts (all one package — `System.Security.Cryptography.Xml` 9.0.0, 8 advisories × 4 projects) confirmed none reach a consumer: it arrives only through `Microsoft.EntityFrameworkCore.Design`, which every `src/` project marks `PrivateAssets=all`. That is the premise `NU1903` staying a warning rests on (`Directory.Build.props`) and the reason [`dependabot.yml`](.github/dependabot.yml) ignores the package under `src/`.

Nothing checked that premise per project. `Sbom_filter_covers_every_private_reference` builds its set with `SelectMany(...).ToHashSet(...)`, flattening all three projects into one collection of ids, so it only ever asks whether a name is *somewhere* private. Drop `PrivateAssets=all` from a single csproj and the other two keep the id in that set — the SBOM test stays green while that one package's nuspec starts declaring the dependency.

## What

`Build_only_references_are_private_in_every_project`: every package id marked `PrivateAssets=all` in any `src/` project must not be referenced publicly by another. General rather than hardcoded to EF Core Design, so it catches the class of drift; the failure message names the project, the id, and the escape hatch if a consumer genuinely needs the package at runtime.

`CLAUDE.md` gains the rationale next to the existing SBOM-filter paragraph.

## Verified (verify-the-guard)

The subject is delivery, so the counterfactual breaks the mechanism rather than reverting a source fix. Removed `PrivateAssets=all` from `Microsoft.EntityFrameworkCore.Design` in `EFCore.ComplexIndexes.SqlServer.csproj` only:

| | broken tree |
|---|---|
| **new guard** | **fails** — `EFCore.ComplexIndexes.SqlServer -> Microsoft.EntityFrameworkCore.Design — marked PrivateAssets=all elsewhere under src/ but not here…` |
| `Sbom_filter_covers_every_private_reference` | **passes** |

That contrast is the reason the test exists.

The stated consequence was checked rather than assumed. Packing the broken project yields a nuspec declaring `<dependency id="Microsoft.EntityFrameworkCore.Design" …>`, and a throwaway consumer restoring it — outside the repo, source-mapped, with a **fresh** `NUGET_PACKAGES` so the good 5.0.3 built minutes earlier could not shadow it — reports all eight advisories on `System.Security.Cryptography.Xml`. The good build of the same package reports none.

Tree restored; full unit suite green at 195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)